### PR TITLE
Add implementation of RLP Decode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories(evm PRIVATE
 add_executable(evm_tests
   tests/main.cpp
   tests/harness.cpp
+  tests/rlp.cpp
 )
 target_include_directories(evm_tests PRIVATE
   ${Boost_INCLUDE_DIR}

--- a/evm/util.cpp
+++ b/evm/util.cpp
@@ -45,18 +45,6 @@ namespace evm
     return v;
   }
 
-  string to_hex_string(const vector<uint8_t>& bytes)
-  {
-    stringstream ss;
-
-    ss << "0x" << hex;
-    for (int b : bytes)
-    {
-      ss << setfill('0') << setw(2) << b;
-    }
-    return ss.str();
-  }
-
   Address generate_address(const Address& sender, uint64_t nonce)
   {
     const auto rlp_encoding = rlp::encode(sender, nonce);

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "bigint.h"
+
 #include <cstdint>
 #include <string>
 #include <tuple>

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -352,11 +352,11 @@ namespace evm
     std::tuple<Ts...> decode_tuple(
       const uint8_t*& data, size_t& size, const std::tuple<Ts...>&)
     {
-      return decode<Ts...>(data, size);
+      return std::tuple_cat(decode<Ts>(data, size)...);
     }
 
     template <typename T>
-    auto decode_first(const uint8_t*& data, size_t& size)
+    auto decode_item(const uint8_t*& data, size_t& size)
     {
       if constexpr (is_tuple<std::decay_t<T>>::value)
       {
@@ -371,7 +371,7 @@ namespace evm
     template <typename T, typename... Ts>
     std::tuple<T, Ts...> decode_multiple(const uint8_t*& data, size_t& size)
     {
-      const auto first = decode_first<T>(data, size);
+      const auto first = decode_item<T>(data, size);
 
       if constexpr (sizeof...(Ts) == 0)
       {

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -348,10 +348,13 @@ namespace evm
       return {Arity::Multiple, content_length};
     }
 
+    // General template for decoding a tuple. Type inferred from of third
+    // parameter (an unused tag)
     template <typename... Ts>
     std::tuple<Ts...> decode_tuple(
       const uint8_t*& data, size_t& size, const std::tuple<Ts...>&);
 
+    // Specialisation for decoding empty tuples
     template <>
     inline std::tuple<> decode_tuple(
       const uint8_t*& data, size_t& size, const std::tuple<>&)
@@ -359,6 +362,8 @@ namespace evm
       return std::make_tuple();
     }
 
+    // Specialisation for recursively decoding tuples, ensuring the first item
+    // is read before the others
     template <typename T, typename... Ts>
     inline std::tuple<T, Ts...> decode_tuple(
       const uint8_t*& data, size_t& size, const std::tuple<T, Ts...>&)
@@ -369,6 +374,9 @@ namespace evm
         first, decode_tuple<Ts...>(data, size, std::tuple<Ts...>{}));
     }
 
+    // Type helper for decoding single item, forwarding to either decode_tuple
+    // (to unwrap the types contained in a tuple) or directly to the main
+    // decode function
     template <typename T>
     auto decode_item(const uint8_t*& data, size_t& size)
     {
@@ -382,6 +390,9 @@ namespace evm
       }
     }
 
+    // Type helper for decoding single item, forwarding to either decode_tuple
+    // (to unwrap the types contained in a tuple) or directly to the main
+    // decode function
     template <typename T, typename... Ts>
     std::tuple<T, Ts...> decode_multiple(const uint8_t*& data, size_t& size)
     {
@@ -397,6 +408,8 @@ namespace evm
       }
     }
 
+    // Main decode function. Reads initial length, then either converts a single
+    // item from remaining bytes or forwards to decode_multiple
     template <typename... Ts>
     std::tuple<Ts...> decode(const uint8_t*& data, size_t& size)
     {
@@ -435,6 +448,8 @@ namespace evm
       }
     }
 
+    // Helper. Takes ByteString and forwards to contained data+size to main
+    // decode function
     template <typename... Ts>
     std::tuple<Ts...> decode(const ByteString& bytes)
     {
@@ -443,6 +458,8 @@ namespace evm
       return decode<Ts...>(data, size);
     }
 
+    // Helper. Unwraps tuple in case where there is a single top-level decoded
+    // value
     template <typename T>
     T decode_single(const ByteString& bytes)
     {

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -388,7 +388,7 @@ namespace evm
     {
       if constexpr (is_tuple<std::decay_t<T>>::value)
       {
-        return decode_tuple(data, size, T{});
+        return std::make_tuple(decode_tuple(data, size, T{}));
       }
       else
       {

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -352,12 +352,12 @@ namespace evm
     // parameter (an unused tag)
     template <typename... Ts>
     std::tuple<Ts...> decode_tuple(
-      const uint8_t*& data, size_t& size, const std::tuple<Ts...>&);
+      const uint8_t*& data, size_t& size, std::tuple<Ts...>);
 
     // Specialisation for decoding empty tuples
     template <>
     inline std::tuple<> decode_tuple(
-      const uint8_t*& data, size_t& size, const std::tuple<>&)
+      const uint8_t*& data, size_t& size, std::tuple<>)
     {
       return std::make_tuple();
     }
@@ -366,7 +366,7 @@ namespace evm
     // is read before the others
     template <typename T, typename... Ts>
     inline std::tuple<T, Ts...> decode_tuple(
-      const uint8_t*& data, size_t& size, const std::tuple<T, Ts...>&)
+      const uint8_t*& data, size_t& size, std::tuple<T, Ts...>)
     {
       const auto first = decode<T>(data, size);
 

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -350,9 +350,23 @@ namespace evm
 
     template <typename... Ts>
     std::tuple<Ts...> decode_tuple(
-      const uint8_t*& data, size_t& size, const std::tuple<Ts...>&)
+      const uint8_t*& data, size_t& size, const std::tuple<Ts...>&);
+
+    template <>
+    inline std::tuple<> decode_tuple(
+      const uint8_t*& data, size_t& size, const std::tuple<>&)
     {
-      return std::tuple_cat(decode<Ts>(data, size)...);
+      return std::make_tuple();
+    }
+
+    template <typename T, typename... Ts>
+    inline std::tuple<T, Ts...> decode_tuple(
+      const uint8_t*& data, size_t& size, const std::tuple<T, Ts...>&)
+    {
+      const auto first = decode<T>(data, size);
+
+      return std::tuple_cat(
+        first, decode_tuple<Ts...>(data, size, std::tuple<Ts...>{}));
     }
 
     template <typename T>

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -272,6 +272,18 @@ namespace evm
       return result;
     }
 
+    template <>
+    inline uint256_t from_bytes<uint256_t>(const uint8_t*& data, size_t& size)
+    {
+      uint256_t result;
+      boost::multiprecision::import_bits(
+        result, data, data + size, std::numeric_limits<uint8_t>::digits, true);
+      data += size;
+      size = 0u;
+
+      return result;
+    }
+
     enum class Arity
     {
       Single,

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -76,7 +76,14 @@ namespace evm
     inline ByteString to_byte_string(const uint256_t& n)
     {
       ByteString bs;
-      boost::multiprecision::export_bits(n, std::back_inserter(bs), 8, true);
+
+      // Need to special-case 0 to return an empty list, not a list containing
+      // a single 0 byte
+      if (n != 0)
+      {
+        boost::multiprecision::export_bits(n, std::back_inserter(bs), 8, true);
+      }
+
       return bs;
     }
 
@@ -275,9 +282,18 @@ namespace evm
     template <>
     inline uint256_t from_bytes<uint256_t>(const uint8_t*& data, size_t& size)
     {
-      uint256_t result;
-      boost::multiprecision::import_bits(
-        result, data, data + size, std::numeric_limits<uint8_t>::digits, true);
+      uint256_t result = 0u;
+
+      if (size > 0)
+      {
+        boost::multiprecision::import_bits(
+          result,
+          data,
+          data + size,
+          std::numeric_limits<uint8_t>::digits,
+          true);
+      }
+
       data += size;
       size = 0u;
 

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -348,10 +348,30 @@ namespace evm
       return {Arity::Multiple, content_length};
     }
 
+    template <typename... Ts>
+    std::tuple<Ts...> decode_tuple(
+      const uint8_t*& data, size_t& size, const std::tuple<Ts...>&)
+    {
+      return decode<Ts...>(data, size);
+    }
+
+    template <typename T>
+    auto decode_first(const uint8_t*& data, size_t& size)
+    {
+      if constexpr (is_tuple<std::decay_t<T>>::value)
+      {
+        return decode_tuple(data, size, T{});
+      }
+      else
+      {
+        return decode<T>(data, size);
+      }
+    }
+
     template <typename T, typename... Ts>
     std::tuple<T, Ts...> decode_multiple(const uint8_t*& data, size_t& size)
     {
-      const auto first = decode<T>(data, size);
+      const auto first = decode_first<T>(data, size);
 
       if constexpr (sizeof...(Ts) == 0)
       {

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -236,6 +236,12 @@ namespace evm
     }
 
     template <>
+    inline int from_bytes<int>(const uint8_t*& data, size_t& size)
+    {
+      return (int)from_bytes<size_t>(data, size);
+    }
+
+    template <>
     inline std::string from_bytes<std::string>(
       const uint8_t*& data, size_t& size)
     {

--- a/include/util.h
+++ b/include/util.h
@@ -57,7 +57,27 @@ namespace evm
 
   std::string strip(const std::string& s);
   std::vector<uint8_t> to_bytes(const std::string& s);
-  std::string to_hex_string(const std::vector<uint8_t>& bytes);
+
+  template <typename Iterator>
+  std::string to_hex_string(Iterator begin, Iterator end)
+  {
+    std::stringstream ss;
+
+    ss << "0x" << std::hex;
+    while (begin != end)
+    {
+      ss << std::setfill('0') << std::setw(2) << (int)*begin;
+      begin++;
+    }
+
+    return ss.str();
+  }
+
+  template <typename T>
+  std::string to_hex_string(const T& bytes)
+  {
+    return to_hex_string(bytes.begin(), bytes.end());
+  }
 
   Address generate_address(const Address& sender, uint64_t nonce);
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -5,7 +5,6 @@
 #include "../include/disassembler.h"
 #include "../include/opcode.h"
 #include "../include/processor.h"
-#include "../include/rlp.h"
 #include "../include/util.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
@@ -128,91 +127,6 @@ TEST_CASE("byteExport" * doctest::test_suite("primitive"))
 
     uint256_t m = from_big_endian(raw.begin(), raw.end());
     REQUIRE(m == n);
-  }
-}
-
-TEST_CASE("rlp" * doctest::test_suite("rlp"))
-{
-  SUBCASE("encode")
-  {
-    CHECK(rlp::encode(0x0) == rlp::ByteString{0x80});
-    CHECK(rlp::encode(0x1) == rlp::ByteString{0x1});
-    CHECK(rlp::encode(0x7f) == rlp::ByteString{0x7f});
-    CHECK(rlp::encode(0x80) == rlp::ByteString{0x81, 0x80});
-
-    CHECK(rlp::encode() == rlp::ByteString{0xc0});
-    CHECK(rlp::encode("") == rlp::ByteString{0x80});
-
-    CHECK(rlp::encode(0x0, 0x0) == rlp::ByteString{0xc2, 0x80, 0x80});
-    CHECK(rlp::encode(0x1, 0x2, 0x3) == rlp::ByteString{0xc3, 0x1, 0x2, 0x3});
-
-    CHECK(rlp::encode("dog") == rlp::ByteString{0x83, 'd', 'o', 'g'});
-    CHECK(
-      rlp::encode("cat", "dog") ==
-      rlp::ByteString{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'});
-
-    CHECK(rlp::encode(1024) == rlp::ByteString{0x82, 0x04, 0x00});
-
-    CHECK(rlp::encode(rlp::ByteString{0x0}) == rlp::ByteString{0x0});
-
-    CHECK(
-      rlp::encode(rlp::ByteString{0x0, 0x0}) ==
-      rlp::ByteString{0x82, 0x0, 0x0});
-
-    CHECK(rlp::encode(std::make_tuple(0x0)) == rlp::ByteString{0xc1, 0x80});
-    CHECK(
-      rlp::encode(std::make_tuple(0x0, 0x0)) ==
-      rlp::ByteString{0xc2, 0x80, 0x80});
-    CHECK(
-      rlp::encode(std::make_tuple(std::make_tuple(0x0))) ==
-      rlp::ByteString{0xc2, 0xc1, 0x80});
-
-    const auto set_0 = std::make_tuple();
-    CHECK(rlp::encode(set_0) == rlp::ByteString{0xc0});
-
-    const auto set_1 = std::make_tuple(set_0);
-    CHECK(rlp::encode(set_1) == rlp::ByteString{0xc1, 0xc0});
-
-    const auto set_2 = std::make_tuple(set_0, set_1);
-    const auto set_3 = std::make_tuple(set_0, set_1, set_2);
-    CHECK(
-      rlp::encode(set_3) ==
-      rlp::ByteString{0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0});
-
-    const auto long_and_nested = std::make_tuple(
-      std::make_tuple("Hello world", "Saluton Mondo"),
-      std::make_tuple(
-        std::make_tuple(
-          std::make_tuple(1),
-          std::make_tuple(2, 3),
-          std::make_tuple(std::make_tuple(4))),
-        66000),
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
-      "tempor incididunt ut labore et dolore magna aliqua");
-    const auto expected = rlp::to_byte_string(
-      "\xf8\xa5\xda\x8bHello world\x8dSaluton "
-      "Mondo\xcd\xc8\xc1\x01\xc2\x02\x03\xc2\xc1\x04\x83\x01\x01\xd0\xb8zLorem "
-      "ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
-      "tempor incididunt ut labore et dolore magna aliqua");
-    CHECK(rlp::encode(long_and_nested) == expected);
-  }
-
-  SUBCASE("uint256_t encode")
-  {
-    const uint256_t a = 1024;
-    CHECK(rlp::encode(a) == rlp::ByteString{0x82, 0x04, 0x00});
-
-    using namespace boost::multiprecision::literals;
-    const uint256_t b = 0x1234567890abcdefdeadbeefcafef00dbaaaad_cppui;
-    CHECK(rlp::encode(b) == rlp::ByteString{0x93, 0x12, 0x34, 0x56, 0x78,
-                                            0x90, 0xab, 0xcd, 0xef, 0xde,
-                                            0xad, 0xbe, 0xef, 0xca, 0xfe,
-                                            0xf0, 0x0d, 0xba, 0xaa, 0xad});
-  }
-
-  SUBCASE("decode")
-  {
-    // Unimplemented
   }
 }
 

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -87,6 +87,48 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(rlp::decode<size_t>(rlp::ByteString{0x7f}) == 0x7f);
   CHECK(rlp::decode<size_t>(rlp::ByteString{0x81, 0x80}) == 0x80);
 
-  // CHECK(rlp::encode() == rlp::ByteString{0xc0});
-  // CHECK(rlp::encode("") == rlp::ByteString{0x80});
+  /*
+  CHECK(rlp::encode() == rlp::ByteString{0xc0});
+  CHECK(rlp::encode("") == rlp::ByteString{0x80});
+
+  CHECK(rlp::encode(0x0, 0x0) == rlp::ByteString{0xc2, 0x80, 0x80});
+  CHECK(rlp::encode(0x1, 0x2, 0x3) == rlp::ByteString{0xc3, 0x1, 0x2, 0x3});
+  */
+
+  CHECK(
+    rlp::decode<std::string>(rlp::ByteString{0x83, 'd', 'o', 'g'}) == "dog");
+
+  /*
+  CHECK(
+    rlp::encode("cat", "dog") ==
+    rlp::ByteString{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'});
+
+  CHECK(rlp::encode(1024) == rlp::ByteString{0x82, 0x04, 0x00});
+
+  CHECK(rlp::encode(rlp::ByteString{0x0}) == rlp::ByteString{0x0});
+
+  CHECK(
+    rlp::encode(rlp::ByteString{0x0, 0x0}) == rlp::ByteString{0x82, 0x0,
+  0x0});
+
+  CHECK(rlp::encode(std::make_tuple(0x0)) == rlp::ByteString{0xc1, 0x80});
+  CHECK(
+    rlp::encode(std::make_tuple(0x0, 0x0)) ==
+    rlp::ByteString{0xc2, 0x80, 0x80});
+  CHECK(
+    rlp::encode(std::make_tuple(std::make_tuple(0x0))) ==
+    rlp::ByteString{0xc2, 0xc1, 0x80});
+
+  const auto set_0 = std::make_tuple();
+  CHECK(rlp::encode(set_0) == rlp::ByteString{0xc0});
+
+  const auto set_1 = std::make_tuple(set_0);
+  CHECK(rlp::encode(set_1) == rlp::ByteString{0xc1, 0xc0});
+
+  const auto set_2 = std::make_tuple(set_0, set_1);
+  const auto set_3 = std::make_tuple(set_0, set_1, set_2);
+  CHECK(
+    rlp::encode(set_3) ==
+    rlp::ByteString{0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0});
+*/
 }

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -174,33 +174,34 @@ bool operator==(const UserType& l, const UserType& r)
     l.d[1] == r.d[1] && l.d[2] == r.d[2];
 }
 
-// TEST_CASE("user types" * doctest::test_suite("rlp"))
-// {
-//   // User types should be converted to ByteString before being passed to RLP,
-//   // and will only be decoded as far as ByteStrings
+TEST_CASE("user types" * doctest::test_suite("rlp"))
+{
+  // User types should be converted to ByteString before being passed to RLP,
+  // and will only be decoded as far as ByteStrings
 
-//   UserType s{42, '!', true, {11, 1001, 100001}};
+  UserType s{42, '!', true, {11, 1001, 100001}};
 
-//   uint8_t* start = (uint8_t*)&s;
-//   rlp::ByteString bs(start, start + sizeof(s));
+  uint8_t* start = (uint8_t*)&s;
+  rlp::ByteString bs(start, start + sizeof(s));
 
-//   const rlp::ByteString encoded = rlp::encode(
-//     "Other data",
-//     std::make_tuple("Awkward", std::make_tuple("Data")),
-//     bs,
-//     "And something afterwards");
+  const auto original = std::make_tuple(
+    "Other data"s,
+    std::make_tuple("Awkward"s, std::make_tuple("Data"s)),
+    bs,
+    "And something afterwards"s);
 
-//   // Decode side currently needs to know structure of entire contents, though
-//   it
-//   // can ignore types and leave everything it doesn't care about as
-//   ByteString const auto tup = rlp::decode<
-//     rlp::ByteString,
-//     std::tuple<rlp::ByteString, std::tuple<rlp::ByteString>>,
-//     rlp::ByteString,
-//     rlp::ByteString>(encoded);
+  const rlp::ByteString encoded = rlp::encode(
+    std::get<0>(original),
+    std::get<1>(original),
+    std::get<2>(original),
+    std::get<3>(original));
 
-//   const auto target = std::get<2>(tup);
-//   const UserType* result = (const UserType*)target.data();
+  // Decode side currently needs to structure of entire contents.
+  // TODO: When decoding to a ByteString, we can ignore the contents
+  const auto tup = rlp::decode_single<decltype(original)>(encoded);
 
-//   REQUIRE(s == *result);
-// }
+  const auto target = std::get<2>(tup);
+  const UserType* result = (const UserType*)target.data();
+
+  REQUIRE(s == *result);
+}

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -1,0 +1,86 @@
+#include "../include/rlp.h"
+
+#include <doctest/doctest.h>
+
+using namespace evm;
+
+TEST_CASE("encode" * doctest::test_suite("rlp"))
+{
+  CHECK(rlp::encode(0x0) == rlp::ByteString{0x80});
+  CHECK(rlp::encode(0x1) == rlp::ByteString{0x1});
+  CHECK(rlp::encode(0x7f) == rlp::ByteString{0x7f});
+  CHECK(rlp::encode(0x80) == rlp::ByteString{0x81, 0x80});
+
+  CHECK(rlp::encode() == rlp::ByteString{0xc0});
+  CHECK(rlp::encode("") == rlp::ByteString{0x80});
+
+  CHECK(rlp::encode(0x0, 0x0) == rlp::ByteString{0xc2, 0x80, 0x80});
+  CHECK(rlp::encode(0x1, 0x2, 0x3) == rlp::ByteString{0xc3, 0x1, 0x2, 0x3});
+
+  CHECK(rlp::encode("dog") == rlp::ByteString{0x83, 'd', 'o', 'g'});
+  CHECK(
+    rlp::encode("cat", "dog") ==
+    rlp::ByteString{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'});
+
+  CHECK(rlp::encode(1024) == rlp::ByteString{0x82, 0x04, 0x00});
+
+  CHECK(rlp::encode(rlp::ByteString{0x0}) == rlp::ByteString{0x0});
+
+  CHECK(
+    rlp::encode(rlp::ByteString{0x0, 0x0}) == rlp::ByteString{0x82, 0x0, 0x0});
+
+  CHECK(rlp::encode(std::make_tuple(0x0)) == rlp::ByteString{0xc1, 0x80});
+  CHECK(
+    rlp::encode(std::make_tuple(0x0, 0x0)) ==
+    rlp::ByteString{0xc2, 0x80, 0x80});
+  CHECK(
+    rlp::encode(std::make_tuple(std::make_tuple(0x0))) ==
+    rlp::ByteString{0xc2, 0xc1, 0x80});
+
+  const auto set_0 = std::make_tuple();
+  CHECK(rlp::encode(set_0) == rlp::ByteString{0xc0});
+
+  const auto set_1 = std::make_tuple(set_0);
+  CHECK(rlp::encode(set_1) == rlp::ByteString{0xc1, 0xc0});
+
+  const auto set_2 = std::make_tuple(set_0, set_1);
+  const auto set_3 = std::make_tuple(set_0, set_1, set_2);
+  CHECK(
+    rlp::encode(set_3) ==
+    rlp::ByteString{0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0});
+
+  const auto long_and_nested = std::make_tuple(
+    std::make_tuple("Hello world", "Saluton Mondo"),
+    std::make_tuple(
+      std::make_tuple(
+        std::make_tuple(1),
+        std::make_tuple(2, 3),
+        std::make_tuple(std::make_tuple(4))),
+      66000),
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
+    "tempor incididunt ut labore et dolore magna aliqua");
+  const auto expected = rlp::to_byte_string(
+    "\xf8\xa5\xda\x8bHello world\x8dSaluton "
+    "Mondo\xcd\xc8\xc1\x01\xc2\x02\x03\xc2\xc1\x04\x83\x01\x01\xd0\xb8zLorem "
+    "ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
+    "tempor incididunt ut labore et dolore magna aliqua");
+  CHECK(rlp::encode(long_and_nested) == expected);
+}
+
+TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
+{
+  const uint256_t a = 1024;
+  CHECK(rlp::encode(a) == rlp::ByteString{0x82, 0x04, 0x00});
+
+  using namespace boost::multiprecision::literals;
+  const uint256_t b = 0x1234567890abcdefdeadbeefcafef00dbaaaad_cppui;
+  CHECK(rlp::encode(b) == rlp::ByteString{0x93, 0x12, 0x34, 0x56, 0x78,
+                                          0x90, 0xab, 0xcd, 0xef, 0xde,
+                                          0xad, 0xbe, 0xef, 0xca, 0xfe,
+                                          0xf0, 0x0d, 0xba, 0xaa, 0xad});
+}
+
+TEST_CASE("decode" * doctest::test_suite("rlp"))
+{
+  // Unimplemented
+}

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -97,20 +97,21 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
 
   CHECK(
     rlp::decode<std::string>(rlp::ByteString{0x83, 'd', 'o', 'g'}) == "dog");
+  // using SS = std::tuple<std::string, std::string>;
+  // CHECK(
+  // rlp::decode<SS>(rlp::ByteString{
+  // 0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'}) == SS{"cat", "dog"});
+
+  CHECK(rlp::decode<size_t>(rlp::ByteString{0x82, 0x04, 0x00}) == 1024);
+
+  CHECK(
+    rlp::decode<rlp::ByteString>(rlp::ByteString{0x0}) == rlp::ByteString{0x0});
+
+  CHECK(
+    rlp::decode<rlp::ByteString>(rlp::ByteString{0x82, 0x0, 0x0}) ==
+    rlp::ByteString{0x0, 0x0});
 
   /*
-  CHECK(
-    rlp::encode("cat", "dog") ==
-    rlp::ByteString{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'});
-
-  CHECK(rlp::encode(1024) == rlp::ByteString{0x82, 0x04, 0x00});
-
-  CHECK(rlp::encode(rlp::ByteString{0x0}) == rlp::ByteString{0x0});
-
-  CHECK(
-    rlp::encode(rlp::ByteString{0x0, 0x0}) == rlp::ByteString{0x82, 0x0,
-  0x0});
-
   CHECK(rlp::encode(std::make_tuple(0x0)) == rlp::ByteString{0xc1, 0x80});
   CHECK(
     rlp::encode(std::make_tuple(0x0, 0x0)) ==
@@ -130,5 +131,5 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(
     rlp::encode(set_3) ==
     rlp::ByteString{0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0});
-*/
+  */
 }

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -87,21 +87,26 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x7f}) == 0x7f);
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x81, 0x80}) == 0x80);
 
+  CHECK(rlp::decode<>(rlp::ByteString{0xc0}) == std::make_tuple());
   /*
   CHECK(rlp::encode() == rlp::ByteString{0xc0});
   CHECK(rlp::encode("") == rlp::ByteString{0x80});
-
-  CHECK(rlp::encode(0x0, 0x0) == rlp::ByteString{0xc2, 0x80, 0x80});
-  CHECK(rlp::encode(0x1, 0x2, 0x3) == rlp::ByteString{0xc3, 0x1, 0x2, 0x3});
   */
 
   CHECK(
-    rlp::decode_single<std::string>(rlp::ByteString{0x83, 'd', 'o', 'g'}) ==
-    "dog");
-  // using SS = std::tuple<std::string, std::string>;
-  // CHECK(
-  // rlp::decode<SS>(rlp::ByteString{
-  // 0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'}) == SS{"cat", "dog"});
+    rlp::decode<size_t, size_t>(rlp::ByteString{0xc2, 0x80, 0x80}) ==
+    std::make_tuple(0x0, 0x0));
+  CHECK(
+    rlp::decode<size_t, size_t, size_t>(rlp::ByteString{0xc3, 0x1, 0x2, 0x3}) ==
+    std::make_tuple(0x1, 0x2, 0x3));
+
+  const rlp::ByteString dog{0x83, 'd', 'o', 'g'};
+  CHECK(rlp::decode_single<std::string>(dog) == "dog");
+  CHECK(rlp::decode<std::string>(dog) == std::make_tuple("dog"));
+
+  // const rlp::ByteString cat_dog{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o',
+  // 'g'}; using SS = std::tuple<std::string, std::string>;
+  // CHECK(rlp::decode<SS>(cat_dog) == SS{"cat", "dog"});
 
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x82, 0x04, 0x00}) == 1024);
 

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -130,17 +130,26 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
       rlp::ByteString{0xc2, 0xc1, 0x80}) ==
     std::make_tuple(std::make_tuple(std::make_tuple(0x0))));
 
-  /*
-  const auto set_0 = std::make_tuple();
-  CHECK(rlp::encode(set_0) == rlp::ByteString{0xc0});
-
-  const auto set_1 = std::make_tuple(set_0);
-  CHECK(rlp::encode(set_1) == rlp::ByteString{0xc1, 0xc0});
-
-  const auto set_2 = std::make_tuple(set_0, set_1);
-  const auto set_3 = std::make_tuple(set_0, set_1, set_2);
   CHECK(
-    rlp::encode(set_3) ==
-    rlp::ByteString{0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0});
-  */
+    rlp::decode_single<
+      std::tuple<size_t, size_t, size_t, size_t, size_t, size_t>>(
+      rlp::ByteString{0xc6, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6}) ==
+    std::make_tuple(0x1, 0x2, 0x3, 0x4, 0x5, 0x6));
+
+  auto set_0 = std::make_tuple();
+  CHECK(rlp::decode_single<decltype(set_0)>(rlp::ByteString{0xc0}) == set_0);
+
+  auto set_1 = std::make_tuple(set_0);
+  CHECK(
+    rlp::decode_single<decltype(set_1)>(rlp::ByteString{0xc1, 0xc0}) == set_1);
+
+  auto set_2 = std::make_tuple(set_0, set_1);
+  CHECK(
+    rlp::decode_single<decltype(set_2)>(
+      rlp::ByteString{0xc3, 0xc0, 0xc1, 0xc0}) == set_2);
+
+  auto set_3 = std::make_tuple(set_0, set_1, set_2);
+  CHECK(
+    rlp::decode_single<decltype(set_3)>(rlp::ByteString{
+      0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0}) == set_3);
 }

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -82,5 +82,11 @@ TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
 
 TEST_CASE("decode" * doctest::test_suite("rlp"))
 {
-  // Unimplemented
+  CHECK(rlp::decode<size_t>(rlp::ByteString{0x80}) == 0x0);
+  CHECK(rlp::decode<size_t>(rlp::ByteString{0x1}) == 0x1);
+  CHECK(rlp::decode<size_t>(rlp::ByteString{0x7f}) == 0x7f);
+  CHECK(rlp::decode<size_t>(rlp::ByteString{0x81, 0x80}) == 0x80);
+
+  // CHECK(rlp::encode() == rlp::ByteString{0xc0});
+  // CHECK(rlp::encode("") == rlp::ByteString{0x80});
 }

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -67,7 +67,7 @@ TEST_CASE("encode" * doctest::test_suite("rlp"))
   CHECK(rlp::encode(long_and_nested) == expected);
 }
 
-TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
+TEST_CASE("uint256_t encode" * doctest::test_suite("rlp"))
 {
   const uint256_t a = 1024;
   CHECK(rlp::encode(a) == rlp::ByteString{0x82, 0x04, 0x00});
@@ -82,6 +82,9 @@ TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
 
 TEST_CASE("decode" * doctest::test_suite("rlp"))
 {
+  // NB: Return value of decode is wrapped in a tuple. If requesting a single
+  // top-level value, this layer can be popped for you by calling decode_single
+  CHECK(rlp::decode<size_t>(rlp::ByteString{0x80}) == std::make_tuple(0x0));
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x80}) == 0x0);
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x1}) == 0x1);
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x7f}) == 0x7f);
@@ -119,12 +122,13 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(
     rlp::decode<std::tuple<size_t>>(rlp::ByteString{0xc1, 0x80}) ==
     std::make_tuple(std::make_tuple(0x0)));
-  // CHECK(
-  //   rlp::decode<std::tuple<size_t, size_t>>(
-  //     rlp::ByteString{0xc2, 0x80, 0x80}) == std::make_tuple(0x0, 0x0));
-  // CHECK(
-  //   rlp::decode<std::tuple<std::tuple<size_t>>>(rlp::ByteString{
-  //     0xc2, 0xc1, 0x80}) == std::make_tuple(std::make_tuple(0x0)));
+  CHECK(
+    rlp::decode<std::tuple<size_t, size_t>>(rlp::ByteString{
+      0xc2, 0x80, 0x80}) == std::make_tuple(std::make_tuple(0x0, 0x0)));
+  CHECK(
+    rlp::decode<std::tuple<std::tuple<size_t>>>(
+      rlp::ByteString{0xc2, 0xc1, 0x80}) ==
+    std::make_tuple(std::make_tuple(std::make_tuple(0x0))));
 
   /*
   const auto set_0 = std::make_tuple();

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -88,10 +88,7 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x81, 0x80}) == 0x80);
 
   CHECK(rlp::decode<>(rlp::ByteString{0xc0}) == std::make_tuple());
-  /*
-  CHECK(rlp::encode() == rlp::ByteString{0xc0});
-  CHECK(rlp::encode("") == rlp::ByteString{0x80});
-  */
+  CHECK(rlp::decode<std::string>(rlp::ByteString{0x80}) == std::make_tuple(""));
 
   CHECK(
     rlp::decode<size_t, size_t>(rlp::ByteString{0xc2, 0x80, 0x80}) ==
@@ -104,9 +101,10 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(rlp::decode_single<std::string>(dog) == "dog");
   CHECK(rlp::decode<std::string>(dog) == std::make_tuple("dog"));
 
-  // const rlp::ByteString cat_dog{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o',
-  // 'g'}; using SS = std::tuple<std::string, std::string>;
-  // CHECK(rlp::decode<SS>(cat_dog) == SS{"cat", "dog"});
+  const rlp::ByteString cat_dog{0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'};
+  CHECK(
+    rlp::decode<std::string, std::string>(cat_dog) ==
+    std::make_tuple("cat", "dog"));
 
   CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x82, 0x04, 0x00}) == 1024);
 
@@ -118,15 +116,17 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
     rlp::decode_single<rlp::ByteString>(rlp::ByteString{0x82, 0x0, 0x0}) ==
     rlp::ByteString{0x0, 0x0});
 
-  /*
-  CHECK(rlp::encode(std::make_tuple(0x0)) == rlp::ByteString{0xc1, 0x80});
   CHECK(
-    rlp::encode(std::make_tuple(0x0, 0x0)) ==
-    rlp::ByteString{0xc2, 0x80, 0x80});
-  CHECK(
-    rlp::encode(std::make_tuple(std::make_tuple(0x0))) ==
-    rlp::ByteString{0xc2, 0xc1, 0x80});
+    rlp::decode<std::tuple<size_t>>(rlp::ByteString{0xc1, 0x80}) ==
+    std::make_tuple(std::make_tuple(0x0)));
+  // CHECK(
+  //   rlp::decode<std::tuple<size_t, size_t>>(
+  //     rlp::ByteString{0xc2, 0x80, 0x80}) == std::make_tuple(0x0, 0x0));
+  // CHECK(
+  //   rlp::decode<std::tuple<std::tuple<size_t>>>(rlp::ByteString{
+  //     0xc2, 0xc1, 0x80}) == std::make_tuple(std::make_tuple(0x0)));
 
+  /*
   const auto set_0 = std::make_tuple();
   CHECK(rlp::encode(set_0) == rlp::ByteString{0xc0});
 

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -243,7 +243,7 @@ TEST_CASE("transaction" * doctest::test_suite("rlp"))
   uint256_t r = 0x0;
   uint256_t s = 0x0;
 
-  const auto tx_hash =
+  const auto tx_rlp =
     rlp::encode(nonce, gas_price, gas_limit, to, value, data, v, r, s);
 
   // Expected result produced from web3.js
@@ -251,5 +251,5 @@ TEST_CASE("transaction" * doctest::test_suite("rlp"))
     "0xe6058609184e72a0008303000094ab2fccb0c5f0499278801ce41f4bccca39676f2d8080"
     "1c8080");
 
-  REQUIRE(tx_hash == expected);
+  REQUIRE(tx_rlp == expected);
 }

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -69,19 +69,6 @@ TEST_CASE("encode" * doctest::test_suite("rlp"))
   CHECK(rlp::encode(large_input_decoded) == large_input_encoded);
 }
 
-TEST_CASE("uint256_t encode" * doctest::test_suite("rlp"))
-{
-  const uint256_t a = 1024;
-  CHECK(rlp::encode(a) == rlp::ByteString{0x82, 0x04, 0x00});
-
-  using namespace boost::multiprecision::literals;
-  const uint256_t b = 0x1234567890abcdefdeadbeefcafef00dbaaaad_cppui;
-  CHECK(rlp::encode(b) == rlp::ByteString{0x93, 0x12, 0x34, 0x56, 0x78,
-                                          0x90, 0xab, 0xcd, 0xef, 0xde,
-                                          0xad, 0xbe, 0xef, 0xca, 0xfe,
-                                          0xf0, 0x0d, 0xba, 0xaa, 0xad});
-}
-
 TEST_CASE("decode" * doctest::test_suite("rlp"))
 {
   // NB: Return value of decode is wrapped in a tuple. If requesting a single
@@ -158,6 +145,34 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   CHECK(
     rlp::decode<decltype(large_input_decoded)>(large_input_encoded) ==
     std::make_tuple(large_input_decoded));
+}
+
+TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
+{
+  uint256_t small_decoded = 1024;
+  auto small_encoded = rlp::ByteString{0x82, 0x04, 0x00};
+
+  using namespace boost::multiprecision::literals;
+  uint256_t large_decoded = 0x1234567890abcdefdeadbeefcafef00dbaaaad_cppui;
+  auto large_encoded =
+    rlp::ByteString{0x93, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0xde,
+                    0xad, 0xbe, 0xef, 0xca, 0xfe, 0xf0, 0x0d, 0xba, 0xaa, 0xad};
+
+  SUBCASE("encode")
+  {
+    CHECK(rlp::encode(small_decoded) == small_encoded);
+    CHECK(rlp::encode(large_decoded) == large_encoded);
+  }
+
+  SUBCASE("decode")
+  {
+    CHECK(
+      rlp::decode_single<decltype(small_decoded)>(small_encoded) ==
+      small_decoded);
+    CHECK(
+      rlp::decode_single<decltype(large_decoded)>(large_encoded) ==
+      large_decoded);
+  }
 }
 
 struct UserType

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -82,10 +82,10 @@ TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
 
 TEST_CASE("decode" * doctest::test_suite("rlp"))
 {
-  CHECK(rlp::decode<size_t>(rlp::ByteString{0x80}) == 0x0);
-  CHECK(rlp::decode<size_t>(rlp::ByteString{0x1}) == 0x1);
-  CHECK(rlp::decode<size_t>(rlp::ByteString{0x7f}) == 0x7f);
-  CHECK(rlp::decode<size_t>(rlp::ByteString{0x81, 0x80}) == 0x80);
+  CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x80}) == 0x0);
+  CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x1}) == 0x1);
+  CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x7f}) == 0x7f);
+  CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x81, 0x80}) == 0x80);
 
   /*
   CHECK(rlp::encode() == rlp::ByteString{0xc0});
@@ -96,19 +96,21 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
   */
 
   CHECK(
-    rlp::decode<std::string>(rlp::ByteString{0x83, 'd', 'o', 'g'}) == "dog");
+    rlp::decode_single<std::string>(rlp::ByteString{0x83, 'd', 'o', 'g'}) ==
+    "dog");
   // using SS = std::tuple<std::string, std::string>;
   // CHECK(
   // rlp::decode<SS>(rlp::ByteString{
   // 0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g'}) == SS{"cat", "dog"});
 
-  CHECK(rlp::decode<size_t>(rlp::ByteString{0x82, 0x04, 0x00}) == 1024);
+  CHECK(rlp::decode_single<size_t>(rlp::ByteString{0x82, 0x04, 0x00}) == 1024);
 
   CHECK(
-    rlp::decode<rlp::ByteString>(rlp::ByteString{0x0}) == rlp::ByteString{0x0});
+    rlp::decode_single<rlp::ByteString>(rlp::ByteString{0x0}) ==
+    rlp::ByteString{0x0});
 
   CHECK(
-    rlp::decode<rlp::ByteString>(rlp::ByteString{0x82, 0x0, 0x0}) ==
+    rlp::decode_single<rlp::ByteString>(rlp::ByteString{0x82, 0x0, 0x0}) ==
     rlp::ByteString{0x0, 0x0});
 
   /*


### PR DESCRIPTION
- Split RLP tests into separate file
- Add RLP decode implementation
- Add RLP decode tests

- Add general to_hex_string

The decoder's not ideal - it only supports a handful of explicit types, and throws heavily templated error messages, but it should be functional.