### PR TITLE
Remove ambiguity on keccak_256 overloads

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -55,19 +55,36 @@ namespace evm
     Keccak_HashFinal(&hi, output);
   }
 
-  inline std::array<uint8_t, 32u> keccak_256(
-    const unsigned char* begin, size_t byte_len)
+  using KeccakHash = std::array<uint8_t, 32u>;
+
+  inline KeccakHash keccak_256(const uint8_t* begin, size_t byte_len)
   {
-    std::array<uint8_t, 32u> h;
+    KeccakHash h;
     keccak_256(begin, byte_len, h.data());
     return h;
   }
 
-  inline std::array<uint8_t, 32u> keccak_256(
-    const std::string& s, size_t skip = 0)
+  inline KeccakHash keccak_256(const std::string& s)
   {
-    skip = std::min(skip, s.size());
-    return keccak_256((const unsigned char*)s.data() + skip, s.size() - skip);
+    return keccak_256((const uint8_t*)s.data(), s.size());
+  }
+
+  inline KeccakHash keccak_256(const std::vector<uint8_t>& v)
+  {
+    return keccak_256(v.data(), v.size());
+  }
+
+  template <size_t N>
+  inline KeccakHash keccak_256(const std::array<uint8_t, N>& a)
+  {
+    return keccak_256(a.data(), N);
+  }
+
+  template <typename T>
+  inline KeccakHash keccak_256_skip(size_t skip, const T& t)
+  {
+    skip = std::min(skip, t.size());
+    return keccak_256((const uint8_t*)t.data() + skip, t.size() - skip);
   }
 
   std::string strip(const std::string& s);
@@ -99,7 +116,7 @@ namespace evm
     auto s = to_lower_hex_str(a);
 
     // Start at index 2 to skip the "0x" prefix
-    const auto h = keccak_256(s, 2);
+    const auto h = keccak_256_skip(2, s);
 
     for (size_t i = 0; i < s.size() - 2; ++i)
     {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -38,7 +38,7 @@ TEST_CASE("util" * doctest::test_suite("util"))
       "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
     REQUIRE(
-      to_hex_string(keccak_256(empty, 5)) ==
+      to_hex_string(keccak_256_skip(5, empty)) ==
       "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
     const std::string s = "Hello world";
@@ -47,11 +47,11 @@ TEST_CASE("util" * doctest::test_suite("util"))
       "0xed6c11b0b5b808960df26f5bfc471d04c1995b0ffd2055925ad1be28d6baadfd");
 
     REQUIRE(
-      to_hex_string(keccak_256(s, 1)) ==
+      to_hex_string(keccak_256_skip(1, s)) ==
       "0x06f5a9ffe20e0fda47399119d5f89e6ea5aa7442fdbc973c365ef4ad993cde12");
 
     REQUIRE(
-      to_hex_string(keccak_256(s, 6)) ==
+      to_hex_string(keccak_256_skip(6, s)) ==
       "0x8452c9b9140222b08593a26daa782707297be9f7b3e8281d7b4974769f19afd0");
   }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -32,27 +32,55 @@ TEST_CASE("util" * doctest::test_suite("util"))
 
   SUBCASE("keccak_256")
   {
-    const std::string empty;
-    REQUIRE(
-      to_hex_string(keccak_256(empty)) ==
-      "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+    constexpr auto empty_hash =
+      "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+    constexpr auto hello_world_hash =
+      "0xed6c11b0b5b808960df26f5bfc471d04c1995b0ffd2055925ad1be28d6baadfd";
+    constexpr auto ello_world_hash =
+      "0x06f5a9ffe20e0fda47399119d5f89e6ea5aa7442fdbc973c365ef4ad993cde12";
+    constexpr auto world_hash =
+      "0x8452c9b9140222b08593a26daa782707297be9f7b3e8281d7b4974769f19afd0";
 
-    REQUIRE(
-      to_hex_string(keccak_256_skip(5, empty)) ==
-      "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+    {
+      INFO("std::string");
 
-    const std::string s = "Hello world";
-    REQUIRE(
-      to_hex_string(keccak_256(s)) ==
-      "0xed6c11b0b5b808960df26f5bfc471d04c1995b0ffd2055925ad1be28d6baadfd");
+      const std::string empty;
+      REQUIRE(to_hex_string(keccak_256(empty)) == empty_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(5, empty)) == empty_hash);
 
-    REQUIRE(
-      to_hex_string(keccak_256_skip(1, s)) ==
-      "0x06f5a9ffe20e0fda47399119d5f89e6ea5aa7442fdbc973c365ef4ad993cde12");
+      const std::string s = "Hello world";
+      REQUIRE(to_hex_string(keccak_256(s)) == hello_world_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(1, s)) == ello_world_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(6, s)) == world_hash);
+    }
 
-    REQUIRE(
-      to_hex_string(keccak_256_skip(6, s)) ==
-      "0x8452c9b9140222b08593a26daa782707297be9f7b3e8281d7b4974769f19afd0");
+    {
+      INFO("std::vector");
+
+      const std::vector<uint8_t> empty;
+      REQUIRE(to_hex_string(keccak_256(empty)) == empty_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(5, empty)) == empty_hash);
+
+      const std::vector<uint8_t> v{
+        'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
+      REQUIRE(to_hex_string(keccak_256(v)) == hello_world_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(1, v)) == ello_world_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(6, v)) == world_hash);
+    }
+
+    {
+      INFO("std::array");
+
+      const std::array<uint8_t, 0> empty;
+      REQUIRE(to_hex_string(keccak_256(empty)) == empty_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(5, empty)) == empty_hash);
+
+      const std::array<uint8_t, 11> a{
+        'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
+      REQUIRE(to_hex_string(keccak_256(a)) == hello_world_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(1, a)) == ello_world_hash);
+      REQUIRE(to_hex_string(keccak_256_skip(6, a)) == world_hash);
+    }
   }
 
   SUBCASE("to_checksum_address")


### PR DESCRIPTION
Because `std::string`s can be implicitly constructed from `const char*`, there were 2 overloads of `keccak_256` with _totally different behaviour_ depending on whether the first argument was a `char *` or `unsigned char*`. The `skip` overload is now given a distinct name and argument reordering so it is only used when explicitly required. Also added overloads for `std::vector` and `std::array`, to simplify calling code.