### PR TITLE
Add RLP support for generic vectors and arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
-[Bb]uild/
+[Bb]uild*/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -38,6 +38,8 @@ namespace evm
     template <typename... Ts>
     ByteString encode(Ts&&... ts);
 
+    void prefix_multiple_length(size_t total_length, ByteString& bs);
+
     inline ByteString to_byte_string(const ByteString& bs)
     {
       return bs;
@@ -46,6 +48,28 @@ namespace evm
     inline ByteString to_byte_string(const std::string& s)
     {
       return ByteString(s.begin(), s.end());
+    }
+
+    template <size_t N>
+    ByteString to_byte_string(const std::array<uint8_t, N>& a)
+    {
+      return ByteString(a.begin(), a.end());
+    }
+
+    template <typename T, size_t N>
+    ByteString to_byte_string(const std::array<T, N>& a)
+    {
+      ByteString combined;
+
+      for (const auto& e : a)
+      {
+        const auto next = encode(e);
+        combined.insert(combined.end(), next.begin(), next.end());
+      }
+
+      prefix_multiple_length(combined.size(), combined);
+
+      return combined;
     }
 
     inline ByteString to_byte_string(uint64_t n)
@@ -85,6 +109,36 @@ namespace evm
       }
 
       return bs;
+    }
+
+    inline void prefix_multiple_length(size_t total_length, ByteString& bs)
+    {
+      // "If the total payload of a list (i.e. the combined length of all its
+      // items being RLP encoded) is 0-55 bytes long, the RLP encoding
+      // consists of a single byte with value 0xc0 plus the length of the list
+      // followed by the concatenation of the RLP encodings of the items. The
+      // range of the first byte is thus [0xc0, 0xf7]."
+      // NB: This _should_ say '0xc0 plus the length of the concatenation of
+      // RLP encoding of the items'
+      if (total_length <= 55)
+      {
+        bs.insert(bs.begin(), 0xc0 + total_length);
+        return;
+      }
+
+      // "If the total payload of a list is more than 55 bytes long, the RLP
+      // encoding consists of a single byte with value 0xf7 plus the length in
+      // bytes of the length of the payload in binary form, followed by the
+      // length of the payload, followed by the concatenation of the RLP
+      // encodings of the items. The range of the first byte is thus [0xf8,
+      // 0xff]."
+      auto total_length_as_bytes = to_byte_string(total_length);
+      const uint8_t length_of_total_length = total_length_as_bytes.size();
+
+      total_length_as_bytes.insert(
+        total_length_as_bytes.begin(), 0xf7 + length_of_total_length);
+      bs.insert(
+        bs.begin(), total_length_as_bytes.begin(), total_length_as_bytes.end());
     }
 
     // RLP-encode a single, non-tuple argument. Convert it to a ByteString,
@@ -173,132 +227,13 @@ namespace evm
         },
         nested_terms);
 
-      // "If the total payload of a list (i.e. the combined length of all its
-      // items being RLP encoded) is 0-55 bytes long, the RLP encoding
-      // consists of a single byte with value 0xc0 plus the length of the list
-      // followed by the concatenation of the RLP encodings of the items. The
-      // range of the first byte is thus [0xc0, 0xf7]."
-      // NB: This _should_ say '0xc0 plus the length of the concatenation of
-      // RLP encoding of the items'
-      if (total_length <= 55)
-      {
-        flattened.insert(flattened.begin(), 0xc0 + total_length);
-        return flattened;
-      }
-
-      // "If the total payload of a list is more than 55 bytes long, the RLP
-      // encoding consists of a single byte with value 0xf7 plus the length in
-      // bytes of the length of the payload in binary form, followed by the
-      // length of the payload, followed by the concatenation of the RLP
-      // encodings of the items. The range of the first byte is thus [0xf8,
-      // 0xff]."
-      auto total_length_as_bytes = to_byte_string(total_length);
-      const uint8_t length_of_total_length = total_length_as_bytes.size();
-
-      total_length_as_bytes.insert(
-        total_length_as_bytes.begin(), 0xf7 + length_of_total_length);
-      flattened.insert(
-        flattened.begin(),
-        total_length_as_bytes.begin(),
-        total_length_as_bytes.end());
+      prefix_multiple_length(total_length, flattened);
       return flattened;
     }
 
     //
     // Decoding
     //
-    class decode_error : public std::logic_error
-    {
-      using logic_error::logic_error;
-    };
-
-    // Forward declaration to allow recursive calls.
-    template <typename... Ts>
-    std::tuple<Ts...> decode(const uint8_t*&, size_t&);
-
-    template <typename T>
-    T from_bytes(const uint8_t*& data, size_t& size);
-
-    template <>
-    inline uint64_t from_bytes<uint64_t>(const uint8_t*& data, size_t& size)
-    {
-      if (size > 8)
-      {
-        throw decode_error(
-          "Trying to decode number: " + std::to_string(size) +
-          " is too many bytes for uint64_t");
-      }
-
-      uint64_t result = 0;
-
-      while (size > 0)
-      {
-        result <<= 8u;
-        result |= *data;
-        data++;
-        size--;
-      }
-
-      return result;
-    }
-
-    template <>
-    inline int from_bytes<int>(const uint8_t*& data, size_t& size)
-    {
-      return (int)from_bytes<size_t>(data, size);
-    }
-
-    template <>
-    inline std::string from_bytes<std::string>(
-      const uint8_t*& data, size_t& size)
-    {
-      std::string result(size, '\0');
-
-      for (auto i = 0u; i < size; ++i)
-      {
-        result[i] = *data++;
-      }
-
-      size = 0u;
-
-      return result;
-    }
-
-    template <>
-    inline ByteString from_bytes<ByteString>(const uint8_t*& data, size_t& size)
-    {
-      ByteString result(size);
-
-      for (auto i = 0u; i < size; ++i)
-      {
-        result[i] = *data++;
-      }
-
-      size = 0u;
-
-      return result;
-    }
-
-    template <>
-    inline uint256_t from_bytes<uint256_t>(const uint8_t*& data, size_t& size)
-    {
-      uint256_t result = 0u;
-
-      if (size > 0)
-      {
-        boost::multiprecision::import_bits(
-          result,
-          data,
-          data + size,
-          std::numeric_limits<uint8_t>::digits,
-          true);
-      }
-
-      data += size;
-      size = 0u;
-
-      return result;
-    }
 
     enum class Arity
     {
@@ -311,6 +246,159 @@ namespace evm
       Arity arity;
       const uint8_t* data;
       size_t length;
+    };
+
+    class decode_error : public std::logic_error
+    {
+      using logic_error::logic_error;
+    };
+
+    // Forward declaration to allow recursive calls.
+    template <typename... Ts>
+    std::tuple<Ts...> decode(const uint8_t*&, size_t&);
+
+    inline std::pair<Arity, size_t> decode_length(
+      const uint8_t*& data, size_t& size);
+
+    template <typename T>
+    struct from_bytes
+    {
+      T operator()(const uint8_t*& data, size_t& size);
+    };
+
+    template <>
+    struct from_bytes<uint64_t>
+    {
+      uint64_t operator()(const uint8_t*& data, size_t& size)
+      {
+        if (size > 8)
+        {
+          throw decode_error(
+            "Trying to decode number: " + std::to_string(size) +
+            " is too many bytes for uint64_t");
+        }
+
+        uint64_t result = 0;
+
+        while (size > 0)
+        {
+          result <<= 8u;
+          result |= *data;
+          data++;
+          size--;
+        }
+
+        return result;
+      }
+    };
+
+    template <>
+    struct from_bytes<int>
+    {
+      int operator()(const uint8_t*& data, size_t& size)
+      {
+        return (int)from_bytes<size_t>{}(data, size);
+      }
+    };
+
+    template <>
+    struct from_bytes<std::string>
+    {
+      std::string operator()(const uint8_t*& data, size_t& size)
+      {
+        std::string result(size, '\0');
+
+        for (auto i = 0u; i < size; ++i)
+        {
+          result[i] = *data++;
+        }
+
+        size = 0u;
+
+        return result;
+      }
+    };
+
+    template <size_t N>
+    struct from_bytes<std::array<uint8_t, N>>
+    {
+      std::array<uint8_t, N> operator()(const uint8_t*& data, size_t& size)
+      {
+        if (size != N)
+        {
+          throw decode_error(
+            "Trying to decode " + std::to_string(N) +
+            " byte array, but given " + std::to_string(size) +
+            " bytes to decode");
+        }
+
+        std::array<uint8_t, N> result;
+        std::copy(data, data + size, result.begin());
+
+        data = data + size;
+        size = 0;
+
+        return result;
+      }
+    };
+
+    template <typename T, size_t N>
+    struct from_bytes<std::array<T, N>>
+    {
+      std::array<T, N> operator()(const uint8_t*& data, size_t& size)
+      {
+        decode_length(data, size);
+
+        std::array<T, N> result;
+        for (auto i = 0u; i < N; ++i)
+        {
+          result[i] = std::get<0>(decode<T>(data, size));
+        }
+
+        return result;
+      }
+    };
+
+    template <>
+    struct from_bytes<ByteString>
+    {
+      ByteString operator()(const uint8_t*& data, size_t& size)
+      {
+        ByteString result(size);
+
+        for (auto i = 0u; i < size; ++i)
+        {
+          result[i] = *data++;
+        }
+
+        size = 0u;
+
+        return result;
+      }
+    };
+
+    template <>
+    struct from_bytes<uint256_t>
+    {
+      uint256_t operator()(const uint8_t*& data, size_t& size)
+      {
+        uint256_t result = 0u;
+
+        if (size > 0)
+        {
+          boost::multiprecision::import_bits(
+            result,
+            data,
+            data + size,
+            std::numeric_limits<uint8_t>::digits,
+            true);
+        }
+
+        data += size;
+        size = 0u;
+
+        return result;
+      }
     };
 
     inline std::pair<Arity, size_t> decode_length(
@@ -355,7 +443,7 @@ namespace evm
 
         // This should advance data and decrement length_of_length to 0
         const size_t content_length =
-          from_bytes<size_t>(data, length_of_length);
+          from_bytes<size_t>{}(data, length_of_length);
         return {Arity::Single, content_length};
       }
 
@@ -378,7 +466,8 @@ namespace evm
 
       size -= length_of_length;
 
-      const size_t content_length = from_bytes<size_t>(data, length_of_length);
+      const size_t content_length =
+        from_bytes<size_t>{}(data, length_of_length);
       return {Arity::Multiple, content_length};
     }
 
@@ -456,7 +545,7 @@ namespace evm
           throw decode_error("Expected single item, but data encodes a list");
         }
 
-        return std::make_tuple(from_bytes<Ts...>(data, contained_length));
+        return std::make_tuple(from_bytes<Ts...>{}(data, contained_length));
       }
 
       if (arity != Arity::Multiple)

--- a/include/rlp.h
+++ b/include/rlp.h
@@ -277,15 +277,12 @@ namespace evm
       const uint8_t*& data, size_t& size);
 
     template <typename T>
-    struct from_bytes
-    {
-      T operator()(const uint8_t*& data, size_t& size);
-    };
+    struct from_bytes;
 
     template <>
-    struct from_bytes<uint64_t>
+    struct from_bytes<size_t>
     {
-      uint64_t operator()(const uint8_t*& data, size_t& size)
+      size_t operator()(const uint8_t*& data, size_t& size)
       {
         if (size > 8)
         {
@@ -294,7 +291,7 @@ namespace evm
             " is too many bytes for uint64_t");
         }
 
-        uint64_t result = 0;
+        size_t result = 0;
 
         while (size > 0)
         {
@@ -308,12 +305,13 @@ namespace evm
       }
     };
 
-    template <>
-    struct from_bytes<int>
+    template <typename T>
+    struct from_bytes
     {
-      int operator()(const uint8_t*& data, size_t& size)
+      std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, T>
+      operator()(const uint8_t*& data, size_t& size)
       {
-        return (int)from_bytes<size_t>{}(data, size);
+        return (T)from_bytes<size_t>{}(data, size);
       }
     };
 

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -197,28 +197,65 @@ TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
   }
 }
 
-// TEST_CASE("nested" * doctest::test_suite("rlp"))
-// {
-//   {
-//     std::array<std::string, 3> a;
-//     a[0] = "Hello";
-//     a[1] = "Hello world";
-//     a[2] = "Saluton mondo";
+TEST_CASE("nested" * doctest::test_suite("rlp"))
+{
+  {
+    using T = std::array<std::string, 3>;
+    {
+      T empty{};
+      const auto encoded = rlp::encode(empty);
+      CHECK(rlp::decode_single<decltype(empty)>(encoded) == empty);
+    }
 
-//     const auto encoded = rlp::encode(a);
-//     CHECK(rlp::decode_single<decltype(a)>(encoded) == a);
-//   }
+    {
+      T a;
+      a[0] = "Hello";
+      a[1] = "Hello world";
+      a[2] = "Saluton mondo";
+      const auto encoded = rlp::encode(a);
+      CHECK(rlp::decode_single<decltype(a)>(encoded) == a);
+    }
+  }
 
-//   {
-//     std::vector<std::string> v;
-//     v.push_back("Hello");
-//     v.push_back("Hello world");
-//     v.push_back("Saluton mondo");
+  {
+    using T = std::vector<std::string>;
+    {
+      T empty{};
+      const auto encoded = rlp::encode(empty);
+      CHECK(rlp::decode_single<decltype(empty)>(encoded) == empty);
+    }
 
-//     const auto encoded = rlp::encode(v);
-//     CHECK(rlp::decode_single<decltype(v)>(encoded) == v);
-//   }
-// }
+    {
+      T v;
+      v.push_back("Hello");
+      v.push_back("Hello world");
+      v.push_back("Saluton mondo");
+      const auto encoded = rlp::encode(v);
+      CHECK(rlp::decode_single<decltype(v)>(encoded) == v);
+    }
+  }
+
+  {
+    using L0 = std::vector<std::string>;
+    using L1 = std::array<L0, 2>;
+    using L2 = std::vector<L1>;
+    using L3 = std::array<L2, 4>;
+    {
+      L3 empty{};
+      const auto encoded = rlp::encode(empty);
+      CHECK(rlp::decode_single<decltype(empty)>(encoded) == empty);
+    }
+
+    {
+      L3 nest{L2{L1{L0{"a", "b"}, L0{"cd", "efghi", "jkl"}}, L1{}},
+              L2{},
+              L2{L1{L0{"mnopqr", "s"}}},
+              L2{L1{L0{"t"}, L0{"uv"}}, L1{L0{"wx"}, L0{"yz"}}}};
+      const auto encoded = rlp::encode(nest);
+      CHECK(rlp::decode_single<decltype(nest)>(encoded) == nest);
+    }
+  }
+}
 
 struct UserType
 {

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -149,6 +149,20 @@ TEST_CASE("decode" * doctest::test_suite("rlp"))
     std::make_tuple(large_input_decoded));
 }
 
+TEST_CASE("arrays" * doctest::test_suite("rlp"))
+{
+  {
+    std::array<uint8_t, 100> a;
+    for (size_t i; i < a.size(); ++i)
+    {
+      a[i] = i * i;
+    }
+
+    const auto encoded = rlp::encode(a);
+    CHECK(rlp::decode_single<decltype(a)>(encoded) == a);
+  }
+}
+
 TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
 {
   uint256_t zero_decoded = 0x0;
@@ -182,6 +196,29 @@ TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
       large_decoded);
   }
 }
+
+// TEST_CASE("nested" * doctest::test_suite("rlp"))
+// {
+//   {
+//     std::array<std::string, 3> a;
+//     a[0] = "Hello";
+//     a[1] = "Hello world";
+//     a[2] = "Saluton mondo";
+
+//     const auto encoded = rlp::encode(a);
+//     CHECK(rlp::decode_single<decltype(a)>(encoded) == a);
+//   }
+
+//   {
+//     std::vector<std::string> v;
+//     v.push_back("Hello");
+//     v.push_back("Hello world");
+//     v.push_back("Saluton mondo");
+
+//     const auto encoded = rlp::encode(v);
+//     CHECK(rlp::decode_single<decltype(v)>(encoded) == v);
+//   }
+// }
 
 struct UserType
 {

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -11,10 +11,10 @@ const auto large_input_decoded = std::make_tuple(
   std::make_tuple("Hello world"s, "Saluton Mondo"s),
   std::make_tuple(
     std::make_tuple(
-      std::make_tuple(1),
-      std::make_tuple(2, 3),
-      std::make_tuple(std::make_tuple(4))),
-    66000),
+      std::make_tuple(1u),
+      std::make_tuple(2u, 3u),
+      std::make_tuple(std::make_tuple(4u))),
+    66000u),
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
   "tempor incididunt ut labore et dolore magna aliqua"s);
 const auto large_input_encoded = rlp::to_byte_string(
@@ -194,6 +194,27 @@ TEST_CASE("uint256_t" * doctest::test_suite("rlp"))
     CHECK(
       rlp::decode_single<decltype(large_decoded)>(large_encoded) ==
       large_decoded);
+  }
+}
+
+TEST_CASE_TEMPLATE(
+  "integral" * doctest::test_suite("rlp"),
+  T,
+  uint8_t,
+  uint16_t,
+  uint32_t,
+  uint64_t)
+{
+  using TVec = std::vector<T>;
+  TVec v{0,
+         1,
+         std::numeric_limits<T>::max(),
+         std::numeric_limits<T>::max() / 2,
+         std::numeric_limits<T>::max() / 3};
+  for (auto n : v)
+  {
+    auto encoded = rlp::encode(n);
+    CHECK(rlp::decode_single<T>(encoded) == n);
   }
 }
 


### PR DESCRIPTION
The tuple input was unnecessarily restrictive; we can also encode and decode arrays and vectors of arbitrary types, as long as those types can be recursively converted.