### PR TITLE
Run CI quick test verbosely

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
   displayName: Make
   workingDirectory: build
 
-- script: 'make test'
+- script: 'ctest -VV'
   displayName: Quick test
   workingDirectory: build
 


### PR DESCRIPTION
`make test` hides the error output, as seen [here](https://circleci.com/gh/microsoft/eEVM/43?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

Instead we use `ctest -VV`, making test output extra-verbose and giving some guidance from CI results.