### PR TITLE
Fix logs format

### DIFF
--- a/include/eEVM/util.h
+++ b/include/eEVM/util.h
@@ -123,6 +123,12 @@ namespace eevm
     return fmt::format("0x{}", intx::hex(v));
   }
 
+  inline std::string to_hex_string_fixed(
+    const uint256_t& v, size_t min_hex_chars)
+  {
+    return fmt::format("0x{:0>{}}", intx::hex(v), min_hex_chars);
+  }
+
   inline auto address_to_hex_string(const Address& v)
   {
     std::stringstream ss;

--- a/include/eEVM/util.h
+++ b/include/eEVM/util.h
@@ -131,12 +131,7 @@ namespace eevm
 
   inline auto address_to_hex_string(const Address& v)
   {
-    std::stringstream ss;
-    ss << "0x" << std::hex << std::setw(40) << std::setfill('0')
-       << to_hex_string(v).substr(2);
-    auto s = ss.str();
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-    return s;
+    return to_hex_string_fixed(v, 40);
   }
 
   template <typename T>
@@ -168,6 +163,11 @@ namespace eevm
         {
           c = std::toupper(c);
         }
+        else
+        {
+          c = std::tolower(c);
+        }
+        
       }
     }
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -25,7 +25,7 @@ namespace eevm
     }
     j["topics"] = topics_array;
 
-    // Fill in fields to be fields for compliance, so this can be parsed by
+    // Fill in all specified fields for compliance, so this can be parsed by
     // standard tools
     j["logIndex"] = "0x0";
     j["blockNumber"] = "0x0";

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -15,13 +15,13 @@ namespace eevm
 
   void to_json(nlohmann::json& j, const LogEntry& log)
   {
-    j["address"] = to_hex_string(log.address);
+    j["address"] = to_checksum_address(log.address);
     j["data"] = to_hex_string(log.data);
 
     auto topics_array = nlohmann::json::array();
     for (const auto& topic : log.topics)
     {
-      topics_array.push_back(to_hex_string(topic));
+      topics_array.push_back(to_hex_string_fixed(topic, 64));
     }
     j["topics"] = topics_array;
   }

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -24,6 +24,14 @@ namespace eevm
       topics_array.push_back(to_hex_string_fixed(topic, 64));
     }
     j["topics"] = topics_array;
+
+    // Fill in fields to be fields for compliance, so this can be parsed by
+    // standard tools
+    j["logIndex"] = "0x0";
+    j["blockNumber"] = "0x0";
+    j["blockHash"] = "0x0";
+    j["transactionHash"] = "0x0";
+    j["transactionIndex"] = "0x0";
   }
 
   void from_json(const nlohmann::json& j, LogEntry& log)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -99,6 +99,33 @@ TEST_CASE(
 
 TEST_CASE("util" * doctest::test_suite("util"))
 {
+  SUBCASE("to_hex_string")
+  {
+    using namespace intx;
+    REQUIRE(to_hex_string(0) == "0x0");
+    REQUIRE(to_hex_string(1) == "0x1");
+    REQUIRE(to_hex_string(0xa) == "0xa");
+    REQUIRE(to_hex_string(0xff) == "0xff");
+    REQUIRE(
+      to_hex_string(
+        0x1234567890abcdef1a1a2b2b3c3c4d4d5e5e6f6f0011223344556677889900aa_u256) ==
+      "0x1234567890abcdef1a1a2b2b3c3c4d4d5e5e6f6f0011223344556677889900aa");
+
+    REQUIRE(to_hex_string_fixed(0, 4) == "0x0000");
+    REQUIRE(to_hex_string_fixed(1, 4) == "0x0001");
+    REQUIRE(
+      to_hex_string_fixed(0xa, 64) ==
+      "0x000000000000000000000000000000000000000000000000000000000000000a");
+    REQUIRE(
+      to_hex_string_fixed(0xff, 64) ==
+      "0x00000000000000000000000000000000000000000000000000000000000000ff");
+    REQUIRE(
+      to_hex_string_fixed(
+        0x1234567890abcdef1a1a2b2b3c3c4d4d5e5e6f6f0011223344556677889900aa_u256,
+        64) ==
+      "0x1234567890abcdef1a1a2b2b3c3c4d4d5e5e6f6f0011223344556677889900aa");
+  }
+
   SUBCASE("to_bytes")
   {
     REQUIRE(to_bytes("") == vector<uint8_t>{});


### PR DESCRIPTION
Some external tools failed to parse our json event log objects, due to the topics being less than 64 hex chars, and missing fields. This PR fixes this, though the new fields aren't useful.